### PR TITLE
Balanced text size adjustment on mobile, simplified nick colouring.

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -235,17 +235,14 @@ else {
 						$users[$nickToHash] = hashNickDjb2($nickToHash);
 					}
 					$nickColour = $users[$nickToHash] % 32;
+					$nick = '<span class="nick'.$nickColour.'">'.$nick.'</span>';
 				}
 
 				echo '<tr class="'.$messageType.'">';
 				echo '<td class="time"><a id="line'.$i.'" href="#line'.$i.'">'.$lineSections[0].'</a></td>';
 				echo '<td class="'.$nickType.'">';
 				if ($nickType === 'user') {
-					echo '&lt;';
-					if ($colourNicks === TRUE) echo '<span class="nick'.$nickColour.'">';
-					echo $nick;
-					if ($colourNicks === TRUE) echo '</span>';
-					echo '&gt;';
+					echo '&lt;'.$nick.'&gt;';
 				}
 				else {
 					echo $nick;

--- a/www/log.css
+++ b/www/log.css
@@ -129,7 +129,15 @@ body
 {
     background: var(--bg);
     color: var(--fg);
+    text-size-adjust: 200%;
+    -webkit-text-size-adjust: 200%;
 }
+
+th, .text {
+    text-size-adjust: 300%;
+    -webkit-text-size-adjust: 300%;
+}
+
 a {
     color: var(--link);
 }
@@ -171,7 +179,7 @@ td
 	text-align: right;
     vertical-align: top;
 	border-right: var(--divider);
-	padding-right: 0.5em;
+    padding-right: 0.5em;
 }
 .spacer
 {
@@ -184,7 +192,7 @@ td
 .text
 {
 	word-wrap: break-word;
-	padding-left: 0.5em;
+    padding: 0em 0.5em;
 }
 .action .text
 {


### PR DESCRIPTION
A slightly hacky solution, but datestamps and names should now be visible on mobile (with message text remaining slightly larger - though now smaller than before).

Also simplified the if statements around nick colouring, to see if that has an impact for users reporting poor performance.